### PR TITLE
Allow portals without explicit names

### DIFF
--- a/src/portal-host.jsx
+++ b/src/portal-host.jsx
@@ -99,7 +99,7 @@ class ConjointmentPortalHost extends ShapeComponent {
   setContent(registeredPortal) {
     const newPortals = Object.assign({}, this.s.portals)
     const portalId = registeredPortal.tt.id
-    const portalName = registeredPortal.p.name
+    const portalName = registeredPortal.getName()
 
     if (!(portalId in newPortals)) throw new Error(`No such portal: ${portalName} (${portalId})`)
 


### PR DESCRIPTION
## Summary
- stop `PortalHost.setContent()` from reading the optional `name` prop through the ShapeComponent prop proxy
- use the portal's existing `getName()` helper instead so unnamed portals still produce a stable error label

## Why
Brainbound system tests hit a browser crash when a `Portal` was rendered without an explicit `name`. `PortalHost.setContent()` accessed `registeredPortal.p.name`, and `set-state-compare` throws `PropertyNotFoundError` for missing optional props.

## Validation
- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm test` currently exits non-zero because this package has no Jest tests configured