### PR TITLE
Use release-patch package for release:patch script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "expo": "~55.0.15",
         "expo-module-scripts": "^55.0.2",
         "react": "19.2.0",
-        "react-native": "0.83.4"
+        "react-native": "0.83.4",
+        "release-patch": "^1.0.0"
       },
       "peerDependencies": {
         "expo": "*",
@@ -12721,6 +12722,16 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/release-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-patch/-/release-patch-1.0.0.tgz",
+      "integrity": "sha512-reIEGt3J0eK2XF4x+YhusAXGxVHt2847iDBhbF+UGMd3JIfvxsiaMl+C1iZAjJCJShQDKJbh/mGquNm4Fy3TyA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "release-patch": "bin/release-patch.js"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "expo-module prepublishOnly",
     "open:ios": "xed example/ios",
     "open:android": "open -a \"Android Studio\" example/android",
-    "release:patch": "git checkout master && git fetch && git merge origin/master && npm version patch -m \"Bump version to %s\" && git push --follow-tags && npm whoami || npm login && npm publish"
+    "release:patch": "release-patch"
   },
   "keywords": [
     "react-native",
@@ -39,7 +39,8 @@
     "expo": "~55.0.15",
     "expo-module-scripts": "^55.0.2",
     "react": "19.2.0",
-    "react-native": "0.83.4"
+    "react-native": "0.83.4",
+    "release-patch": "^1.0.0"
   },
   "peerDependencies": {
     "expo": "*",


### PR DESCRIPTION
## Summary

Replaces this repo's custom `release:patch` script with the reusable [`release-patch`](https://github.com/kaspernj/release-patch) CLI ([npm](https://www.npmjs.com/package/release-patch)), so the release flow is shared across packages instead of duplicated per repo.

- Sets `"release:patch": "release-patch"`
- Adds `release-patch` as a devDependency

`release-patch` syncs `master`, runs `npm run build` when a `build` script exists, bumps the patch version without a tag, installs, commits, pushes to `master`, and publishes.

## Test plan

- `release-patch` bin resolves via `node_modules/.bin/release-patch`
- Not executed locally (it performs a real release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
